### PR TITLE
Add PostgreSQL connection configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment configuration
+DATABASE_URL=postgresql://user:password@localhost:5432/mydb

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ next-env.d.ts
 
 .genkit/*
 .env*
+!.env.example
 
 # firebase
 firebase-debug.log

--- a/README.md
+++ b/README.md
@@ -3,4 +3,14 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
-"# studio" 
+"# studio"
+
+## Database
+
+This project supports connecting to a PostgreSQL database via the [`pg`](https://www.npmjs.com/package/pg) package. Configure the connection string in a `.env` file using the `DATABASE_URL` variable:
+
+```
+DATABASE_URL=postgresql://user:password@localhost:5432/mydb
+```
+
+An example configuration is provided in `.env.example`.

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,10 @@
+import { Pool } from 'pg';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+export default pool;

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "embla-carousel-react": "^8.6.0",
     "firebase": "^11.9.1",
     "genkit": "^1.14.1",
+    "pg": "^8.11.3",
     "lucide-react": "^0.475.0",
     "next": "15.3.3",
     "patch-package": "^8.0.0",


### PR DESCRIPTION
## Summary
- add `pg` dependency and helper to connect using `DATABASE_URL`
- provide `.env.example` and document setup
- allow committing `.env.example` in `.gitignore`

## Testing
- `pnpm add pg@^8.11.3` *(fails: GET https://registry.npmjs.org/pg: Forbidden - 403)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/pg)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_689a58dd4e9483218082a4f225bdb68f